### PR TITLE
Add missing error handling for failed http calls that stops metrics from being populated ever again

### DIFF
--- a/lib/fluent/plugin/in_kubernetes_metrics_aggregator.rb
+++ b/lib/fluent/plugin/in_kubernetes_metrics_aggregator.rb
@@ -363,6 +363,9 @@ module Fluent
       def scrape_limits_requests_metrics
         response = limits_requests_api.get(@client.headers)
         handle_limits_requests_res(response)
+      rescue StandardError => e
+        log.error "Failed to scrape metrics, error=#{$ERROR_INFO}, #{e.inspect}"
+        log.error_backtrace
       end
 
       # This method is used to handle responses from the kube apiserver api
@@ -462,6 +465,9 @@ module Fluent
       def scrape_node_metrics
         response = node_api.get(@client.headers)
         handle_node_response(response)
+      rescue StandardError => e
+        log.error "Failed to scrape metrics, error=#{$ERROR_INFO}, #{e.inspect}"
+        log.error_backtrace
       end
 
       # This method is used to handle responses from the kubeapiserver api
@@ -535,6 +541,9 @@ module Fluent
       def scrape_resource_usage_metrics
         response = resource_usage_api.get(@client.headers)
         handle_resource_usage_response(response)
+      rescue StandardError => e
+        log.error "Failed to scrape metrics, error=#{$ERROR_INFO}, #{e.inspect}"
+        log.error_backtrace
       end
 
       # This method is used to handle responses from the kubelet summary api

--- a/lib/fluent/plugin/in_kubernetes_metrics_aggregator.rb
+++ b/lib/fluent/plugin/in_kubernetes_metrics_aggregator.rb
@@ -364,7 +364,7 @@ module Fluent
         response = limits_requests_api.get(@client.headers)
         handle_limits_requests_res(response)
       rescue StandardError => e
-        log.error "Failed to scrape metrics, error=#{$ERROR_INFO}, #{e.inspect}"
+        log.error "Failed to get limit metrics, error=#{$ERROR_INFO}, #{e.inspect}"
         log.error_backtrace
       end
 
@@ -378,7 +378,7 @@ module Fluent
           log.error "ExMultiJson.load(response.body) expected 2xx from summary API, but got #{response.code}. Response body = #{response.body}"
         end
       rescue StandardError => e
-        log.error "Failed to scrape metrics, error=#{$ERROR_INFO}, #{e.inspect}"
+        log.error "Failed to scrape limit metrics, error=#{$ERROR_INFO}, #{e.inspect}"
         log.error_backtrace
       end
 
@@ -466,7 +466,7 @@ module Fluent
         response = node_api.get(@client.headers)
         handle_node_response(response)
       rescue StandardError => e
-        log.error "Failed to scrape metrics, error=#{$ERROR_INFO}, #{e.inspect}"
+        log.error "Failed to get node metrics, error=#{$ERROR_INFO}, #{e.inspect}"
         log.error_backtrace
       end
 
@@ -480,7 +480,7 @@ module Fluent
           log.error "ExMultiJson.load(response.body) expected 2xx from summary API, but got #{response.code}. Response body = #{response.body}"
         end
       rescue StandardError => e
-        log.error "Failed to scrape metrics, error=#{$ERROR_INFO}, #{e.inspect}"
+        log.error "Failed to scrape node metrics, error=#{$ERROR_INFO}, #{e.inspect}"
         log.error_backtrace
       end
 
@@ -541,9 +541,9 @@ module Fluent
       def scrape_resource_usage_metrics
         response = resource_usage_api.get(@client.headers)
         handle_resource_usage_response(response)
-      rescue StandardError => e
-        log.error "Failed to scrape metrics, error=#{$ERROR_INFO}, #{e.inspect}"
-        log.error_backtrace
+       rescue StandardError => e
+         log.error "Failed to get resource usage metrics, error=#{$ERROR_INFO}, #{e.inspect}"
+         log.error_backtrace
       end
 
       # This method is used to handle responses from the kubelet summary api
@@ -556,7 +556,7 @@ module Fluent
           log.error "ExMultiJson.load(response.body) expected 2xx from summary API, but got #{response.code}. Response body = #{response.body}"
         end
       rescue StandardError => e
-        log.error "Failed to scrape metrics, error=#{$ERROR_INFO}, #{e.inspect}"
+        log.error "Failed to scrape resource usage metrics, error=#{$ERROR_INFO}, #{e.inspect}"
         log.error_backtrace
       end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -91,6 +91,8 @@ module PluginTestHelper
                'Host' => 'node.fakedestination.com:10255'
              }
            )
+           .to_timeout
+           .then
            .to_return(status: 200,
                       body: File.open(File.expand_path('../pods.json', __FILE__)),
                       headers: {})
@@ -106,6 +108,8 @@ module PluginTestHelper
                'Host' => 'node.fakedestination.com:10255'
              }
            )
+           .to_timeout
+           .then
            .to_return(status: 200,
                       body: File.open(File.expand_path('../node1.json', __FILE__)),
                       headers: {})
@@ -121,6 +125,8 @@ module PluginTestHelper
                'Host' => 'node.fakedestination.com:10255'
              }
            )
+           .to_timeout
+           .then
            .to_return(status: 200,
                       body: File.open(File.expand_path('../node2.json', __FILE__)),
                       headers: {})
@@ -136,6 +142,8 @@ module PluginTestHelper
                'Host' => 'node.fakedestination.com:10255'
              }
            )
+           .to_timeout
+           .then
            .to_return(status: 200,
                       body: File.open(File.expand_path('../node3.json', __FILE__)),
                       headers: {})
@@ -151,6 +159,8 @@ module PluginTestHelper
                'Host' => 'node.fakedestination.com:10255'
              }
            )
+           .to_timeout.then.to_timeout
+           .then
            .to_return(status: 200,
                       body: File.open(File.expand_path('../nodes.json', __FILE__)),
                       headers: {})

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -37,20 +37,6 @@ module PluginTestHelper
     k8s_url + '/v1/nodes/generics-aws-node-three:10255/proxy/stats/summary'
   end
 
-  def stub_api_port_10250
-    WebMock.stub_request(:get, 'https://node.fakedestination.com:10250/api')
-           .with(
-             headers: {
-               'Accept' => '*/*',
-               'Accept-Encoding' => 'gzip, deflate',
-               'Host' => 'node.fakedestination.com:10250'
-             }
-           )
-           .to_return(status: 200,
-                      body: File.open(File.expand_path('../v1.json', __FILE__)),
-                      headers: {})
-  end
-
   def stub_api_port_10255
     WebMock.stub_request(:get,
                          'https://node.fakedestination.com:10255/api')
@@ -81,21 +67,23 @@ module PluginTestHelper
                       headers: {})
   end
 
-  def stub_api_pods
-    WebMock.stub_request(:get,
-                         'https://node.fakedestination.com:10255/api/v1/pods')
-           .with(
-             headers: {
-               'Accept' => '*/*',
-               'Accept-Encoding' => 'gzip, deflate',
-               'Host' => 'node.fakedestination.com:10255'
-             }
-           )
-           .to_timeout
-           .then
-           .to_return(status: 200,
-                      body: File.open(File.expand_path('../pods.json', __FILE__)),
-                      headers: {})
+  def stub_api_pods(timeout=false)
+    get_pods = WebMock.stub_request(:get,
+                                    'https://node.fakedestination.com:10255/api/v1/pods')
+                   .with(
+                       headers: {
+                           'Accept' => '*/*',
+                           'Accept-Encoding' => 'gzip, deflate',
+                           'Host' => 'node.fakedestination.com:10255'
+                       }
+                   )
+    if timeout
+      get_pods = get_pods.to_timeout.then
+    end
+
+    get_pods.to_return(status: 200,
+                       body: File.open(File.expand_path('../pods.json', __FILE__)),
+                       headers: {})
   end
 
   def stub_api_node_1
@@ -108,16 +96,14 @@ module PluginTestHelper
                'Host' => 'node.fakedestination.com:10255'
              }
            )
-           .to_timeout
-           .then
            .to_return(status: 200,
                       body: File.open(File.expand_path('../node1.json', __FILE__)),
                       headers: {})
   end
 
-  def stub_api_node_2
-    WebMock.stub_request(:get,
-                         'https://node.fakedestination.com:10255/api/v1/nodes/generics-aws-node-two:10255/proxy/stats/summary')
+  def stub_api_node_2(timeout=false)
+    get_node_summary = WebMock.stub_request(:get,
+                                            'https://node.fakedestination.com:10255/api/v1/nodes/generics-aws-node-two:10255/proxy/stats/summary')
            .with(
              headers: {
                'Accept' => '*/*',
@@ -125,9 +111,12 @@ module PluginTestHelper
                'Host' => 'node.fakedestination.com:10255'
              }
            )
-           .to_timeout
-           .then
-           .to_return(status: 200,
+
+    if timeout
+      get_node_summary = get_node_summary.to_timeout
+    end
+
+    get_node_summary.to_return(status: 200,
                       body: File.open(File.expand_path('../node2.json', __FILE__)),
                       headers: {})
   end
@@ -142,39 +131,46 @@ module PluginTestHelper
                'Host' => 'node.fakedestination.com:10255'
              }
            )
-           .to_timeout
-           .then
            .to_return(status: 200,
                       body: File.open(File.expand_path('../node3.json', __FILE__)),
                       headers: {})
   end
 
-  def stub_api_nodes
-    WebMock.stub_request(:get,
-                         'https://node.fakedestination.com:10255/api/v1/nodes')
-           .with(
-             headers: {
-               'Accept' => '*/*',
-               'Accept-Encoding' => 'gzip, deflate',
-               'Host' => 'node.fakedestination.com:10255'
-             }
-           )
-           .to_timeout.then.to_timeout
-           .then
-           .to_return(status: 200,
-                      body: File.open(File.expand_path('../nodes.json', __FILE__)),
-                      headers: {})
+  def stub_api_nodes(timeout=false)
+    get_nodes = WebMock.stub_request(:get, 'https://node.fakedestination.com:10255/api/v1/nodes')
+                    .with(
+                        headers: {
+                            'Accept' => '*/*',
+                            'Accept-Encoding' => 'gzip, deflate',
+                            'Host' => 'node.fakedestination.com:10255'
+                        }
+                    )
+
+    if timeout
+      get_nodes = get_nodes.to_timeout.times(2) # Nodes endpoint is called from two timers so must fail in both cases
+    end
+
+    get_nodes.to_return(status: 200,
+               body: File.open(File.expand_path('../nodes.json', __FILE__)),
+               headers: {})
   end
 
-  def stub_k8s_requests
-    stub_api_port_10250
+  def stub_k8s_init_requests
+    WebMock.reset!
+
+    stub_api_port_10255
+  end
+
+  def stub_k8s_requests(nodes_timeout: false, node_summary_timeout: false, pods_timeout: false)
+    WebMock.reset!
+
     stub_api_port_10255
     stub_api_v1
-    stub_api_pods
-    stub_api_nodes
+    stub_api_pods(pods_timeout)
+    stub_api_nodes(nodes_timeout)
     stub_api_node_1
+    stub_api_node_2(node_summary_timeout)
     stub_api_node_3
-    stub_api_node_2
   end
 
   def get_parsed_file(file_name)

--- a/test/plugin/test_in_kubernetes_metrics_aggregator.rb
+++ b/test/plugin/test_in_kubernetes_metrics_aggregator.rb
@@ -43,7 +43,7 @@ class KubernetesMetricsAggInputTest < Test::Unit::TestCase
     ENV['KUBERNETES_SERVICE_PORT'] = "10255"
     stub_k8s_requests
     @driver = create_driver(METRIC_TEST_CONFIG)
-    @driver.run timeout: 20, expect_emits: 200, shutdown: false
+    @driver.run timeout: 30, expect_emits: 200, shutdown: false
 
     @driver.events.each do |tag, time, record|
       @@hash_map_test[tag] = tag, time, record

--- a/test/plugin/test_in_kubernetes_metrics_aggregator.rb
+++ b/test/plugin/test_in_kubernetes_metrics_aggregator.rb
@@ -5,10 +5,6 @@ class KubernetesMetricsAggInputTest < Test::Unit::TestCase
   include Fluent::Test::Helpers
   include PluginTestHelper
 
-  @driver = nil
-  @driver_test = nil
-  @@hash_map_test = {}
-
   ZERO_CONFIG = %([
   ]).freeze
 
@@ -34,20 +30,22 @@ class KubernetesMetricsAggInputTest < Test::Unit::TestCase
   METRIC_TEST_CONFIG = %([
       kubernetes_url https://node.fakedestination.com
       kubelet_port 10255
+      interval 5s
+      tag kube.*
+  ]).freeze
+
+  TIMEOUT_TEST_CONFIG = %([
+      kubernetes_url https://node.fakedestination.com
+      kubelet_port 10255
+      interval 5s
       tag kube.*
   ]).freeze
 
   setup do
     Fluent::Test.setup
+
     ENV['KUBERNETES_SERVICE_HOST'] = "node.fakedestination.com"
     ENV['KUBERNETES_SERVICE_PORT'] = "10255"
-    stub_k8s_requests
-    @driver = create_driver(METRIC_TEST_CONFIG)
-    @driver.run timeout: 30, expect_emits: 200, shutdown: false
-
-    @driver.events.each do |tag, time, record|
-      @@hash_map_test[tag] = tag, time, record
-    end
   end
 
   def create_driver(conf = BASIC_CONFIG)
@@ -60,6 +58,8 @@ class KubernetesMetricsAggInputTest < Test::Unit::TestCase
 
   sub_test_case 'default parameter configuration' do
     test 'test default params' do
+      stub_k8s_init_requests
+
       d = create_driver(ZERO_CONFIG)
       assert_equal 10_250, d.instance.kubelet_port
       assert_equal 'kubernetes.metrics.*', d.instance.tag
@@ -78,141 +78,174 @@ class KubernetesMetricsAggInputTest < Test::Unit::TestCase
 
   sub_test_case 'modify parameter changes' do
     test 'test kubelet_port and supplied kubernetes URL parameters' do
+      stub_k8s_init_requests
+
       d = create_driver(ADVANCED_CONFIG_NO_CERTS)
       assert_equal 'https://node.fakedestination.com', d.instance.kubernetes_url
       assert_equal 10_255, d.instance.kubelet_port
     end
 
     test 'test tag and interval parameters' do
+      stub_k8s_init_requests
+
       d = create_driver(ADVANCED_CONFIG_NO_CERTS)
       assert_equal 'test.tag.check', d.instance.tag
       assert_equal 120, d.instance.interval
     end
 
     test 'test insecure_ssl and cluster_name parameters ' do
+      stub_k8s_init_requests
+
       d = create_driver(ADVANCED_CONFIG_NO_CERTS)
       assert_true d.instance.insecure_ssl
       assert_equal 'awesome_cluster', d.instance.cluster_name
     end
   end
 
-  sub_test_case 'Test metrics exist, limits_request_scraper - limits' do
-    test 'Testing kube.container.memory.limit' do
-      assert_true @@hash_map_test.key?('kube.container.memory.limit')
-    end
+  sub_test_case 'Test metrics exist' do
+    test 'Testing all expected metrics are emitted' do
+      stub_k8s_requests
 
-    test 'Testing kube.namespace.cpu.limit' do
-      assert_true @@hash_map_test.key?('kube.namespace.cpu.limit')
-    end
+      hash_map_test = {}
 
-    test 'Testing kube.namespace.memory.limit	' do
-      assert_true @@hash_map_test.key?('kube.namespace.memory.limit')
-    end
+      d = create_driver(METRIC_TEST_CONFIG)
+      d.run timeout: 12, expect_emits: 200, shutdown: false
 
-    test 'Testing kube.container.cpu.limit' do
-      assert_true @@hash_map_test.key?('kube.container.cpu.limit')
-    end
+      d.events.each do |tag, time, record|
+        hash_map_test[tag] = tag, time, record
+      end
 
-    test 'Testing kube.pod.cpu.limit' do
-      assert_true @@hash_map_test.key?('kube.pod.cpu.limit')
-    end
+      # Test metrics exist, limits_request_scraper - limits
+      assert_true hash_map_test.key?('kube.namespace.cpu.limit')
+      assert_true hash_map_test.key?('kube.namespace.memory.limit')
+      assert_true hash_map_test.key?('kube.container.cpu.limit')
+      assert_true hash_map_test.key?('kube.pod.cpu.limit')
+      assert_true hash_map_test.key?('kube.cluster.memory.limit')
+      assert_true hash_map_test.key?('kube.pod.memory.limit')
+      assert_true hash_map_test.key?('kube.cluster.cpu.limit')
 
-    test 'Testing kube.cluster.memory.limit	' do
-      assert_true @@hash_map_test.key?('kube.cluster.memory.limit')
-    end
+      # Test metrics exist, limits_request_scraper - request
+      assert_true hash_map_test.key?('kube.cluster.memory.request')
+      assert_true hash_map_test.key?('kube.container.memory.request')
+      assert_true hash_map_test.key?('kube.pod.memory.request')
+      assert_true hash_map_test.key?('kube.namespace.memory.request')
+      assert_true hash_map_test.key?('kube.container.cpu.request')
+      assert_true hash_map_test.key?('kube.namespace.cpu.request')
+      assert_true hash_map_test.key?('kube.pod.cpu.request')
+      assert_true hash_map_test.key?('kube.cluster.cpu.request')
 
-    test 'Testing kube.pod.memory.limit	' do
-      assert_true @@hash_map_test.key?('kube.pod.memory.limit')
-    end
+      # Test metrics exist, node_scraper/resource_usage_scraper 1
+      assert_true hash_map_test.key?('kube.node.cpu.capacity')
+      assert_true hash_map_test.key?('kube.node.memory.capacity')
+      assert_true hash_map_test.key?('kube.node.memory.allocatable')
+      assert_true hash_map_test.key?('kube.node.cpu.utilization')
+      assert_true hash_map_test.key?('kube.node.memory.reservation')
+      assert_true hash_map_test.key?('kube.node.memory.utilization')
 
-    test 'Testing kube.cluster.cpu.limit' do
-      assert_true @@hash_map_test.key?('kube.cluster.cpu.limit')
+      # Test metrics exist, node_scraper/resource_usage_scraper 2
+      assert_true hash_map_test.key?('kube.namespace.memory.usage')
+      assert_true hash_map_test.key?('kube.cluster.memory.usage')
+      assert_true hash_map_test.key?('kube.namespace.cpu.usage')
+      assert_true hash_map_test.key?('kube.node.cpu.allocatable')
+      assert_true hash_map_test.key?('kube.node.cpu.reservation')
+      assert_true hash_map_test.key?('kube.cluster.cpu.usage')
+
+      d.instance_shutdown
     end
   end
 
-  sub_test_case 'Test metrics exist, limits_request_scraper - request' do
-    test 'Testing kube.cluster.memory.request	' do
-      assert_true @@hash_map_test.key?('kube.cluster.memory.request')
+  sub_test_case 'Test handles request timeouts' do
+
+    test 'Testing event count with nodes call timeout' do
+      stub_k8s_requests(nodes_timeout: true)
+
+      namespace_event_count = 0
+      pod_event_count = 0
+      node_event_count = 0
+
+      d = create_driver(TIMEOUT_TEST_CONFIG)
+      # Should run for two intervals, the first call to node 1 which has the only 'default' namespace pod should timeout the first time
+      d.run timeout: 12, expect_emits: 500, shutdown: false
+
+      d.events.each do |tag, _time, record|
+        # Limit to one events that should be emitted once per interval
+        if tag == 'kube.pod.cpu.limit' && record['name'] == 'new-metrics-test-final-splunk-kubernetes-metrics-fgszl'
+          pod_event_count += 1
+        end
+        if tag == 'kube.namespace.cpu.usage' && record['name'] == 'kube-system'
+          namespace_event_count += 1
+        end
+        if tag == 'kube.node.cpu.capacity' && record['node'] == 'generics-aws-node-one'
+          node_event_count += 1
+        end
+      end
+
+      # 2 intervals - first call times out but timer continues emitting successfully next interval
+      assert_equal 1, node_event_count, 'Number of node events emitted was wrong'
+      # 2 intervals - first call times out but timer continues emitting successfully next interval
+      assert_equal 1, namespace_event_count, 'Number of namespace events emitted was wrong'
+      # 2 intervals - not timeouts
+      assert_equal 2, pod_event_count, 'Number of pod events emitted was wrong'
+
+      d.instance_shutdown
     end
 
-    test 'Testing kube.container.memory.request' do
-      assert_true @@hash_map_test.key?('kube.container.memory.request')
+    test 'Testing event count with pods call timeout' do
+      stub_k8s_requests(pods_timeout: true)
+
+      pod_event_count = 0
+      node_event_count = 0
+
+      d = create_driver(TIMEOUT_TEST_CONFIG)
+      # Should run for two intervals, the first call to node 1 which has the only 'default' namespace pod should timeout the first time
+      d.run timeout: 12, expect_emits: 500, shutdown: false
+
+      d.events.each do |tag, _time, record|
+        # Limit to one events that should be emitted once per interval
+        if tag == 'kube.pod.cpu.limit' && record['name'] == 'new-metrics-test-final-splunk-kubernetes-metrics-fgszl'
+          pod_event_count += 1
+        end
+
+        if tag == 'kube.node.cpu.utilization' && record['node'] == 'generics-aws-node-one'
+          node_event_count += 1
+        end
+      end
+
+      # 2 intervals - first call times out but timer continues emitting successfully next interval
+      assert_equal 1, pod_event_count, 'Number of pod events emitted was wrong'
+      # 2 intervals - not timeouts
+      assert_equal 2, node_event_count, 'Number of namespace events emitted was wrong'
+
+      d.instance_shutdown
     end
 
-    test 'Testing kube.pod.memory.request' do
-      assert_true @@hash_map_test.key?('kube.pod.memory.request')
+    test 'Testing event count with node summary call timeout' do
+      stub_k8s_requests(node_summary_timeout: true)
+
+      namespace_event_count = 0
+      pod_event_count = 0
+
+      d = create_driver(TIMEOUT_TEST_CONFIG)
+      # Should run for two intervals, the first call to node 1 which has the only 'default' namespace pod should timeout the first time
+      d.run timeout: 12, expect_emits: 500, shutdown: false
+
+      d.events.each do |tag, _time, record|
+        # Limit to one events that should be emitted once per interval
+        if tag == 'kube.namespace.cpu.usage' && record['name'] == 'kube-system'
+          namespace_event_count += 1
+        end
+        if tag == 'kube.pod.cpu.limit' && record['name'] == 'new-metrics-test-final-splunk-kubernetes-metrics-fgszl'
+          pod_event_count += 1
+        end
+      end
+
+      # 2 intervals - first call times out but timer continues emitting successfully next interval
+      assert_equal 1, namespace_event_count, 'Number of namespace events emitted was wrong'
+      # 2 intervals - not timeouts
+      assert_equal 2, pod_event_count, 'Number of pod events emitted was wrong'
+
+      d.instance_shutdown
     end
 
-    test 'Testing kube.namespace.memory.request	' do
-      assert_true @@hash_map_test.key?('kube.namespace.memory.request')
-    end
-
-    test 'Testing kube.container.cpu.request' do
-      assert_true @@hash_map_test.key?('kube.container.cpu.request')
-    end
-
-    test 'Testing kube.namespace.cpu.request' do
-      assert_true @@hash_map_test.key?('kube.namespace.cpu.request')
-    end
-
-    test 'Testing kube.pod.cpu.request' do
-      assert_true @@hash_map_test.key?('kube.pod.cpu.request')
-    end
-
-    test 'Testing kube.cluster.cpu.request' do
-      assert_true @@hash_map_test.key?('kube.cluster.cpu.request')
-    end
-  end
-
-  sub_test_case 'Test metrics exist, node_scraper/resource_usage_scraper 1' do
-    test 'Testing kube.node.cpu.capacity' do
-      assert_true @@hash_map_test.key?('kube.node.cpu.capacity')
-    end
-
-    test 'Testing kube.node.memory.capacity	' do
-      assert_true @@hash_map_test.key?('kube.node.memory.capacity')
-    end
-
-    test 'Testing kube.node.memory.allocatable' do
-      assert_true @@hash_map_test.key?('kube.node.memory.allocatable')
-    end
-
-    test 'Testing kube.node.cpu.utilization	' do
-      assert_true @@hash_map_test.key?('kube.node.cpu.utilization')
-    end
-
-    test 'Testing kube.node.memory.reservation' do
-      assert_true @@hash_map_test.key?('kube.node.memory.reservation')
-    end
-
-    test 'Testing kube.node.memory.utilization' do
-      assert_true @@hash_map_test.key?('kube.node.memory.utilization')
-    end
-  end
-
-  sub_test_case 'Test metrics exist, node_scraper/resource_usage_scraper 2' do
-    test 'Testing kube.namespace.memory.usage	' do
-      assert_true @@hash_map_test.key?('kube.namespace.memory.usage')
-    end
-
-    test 'Testing kube.cluster.memory.usage' do
-      assert_true @@hash_map_test.key?('kube.cluster.memory.usage')
-    end
-
-    test 'Testing kube.namespace.cpu.usage' do
-      assert_true @@hash_map_test.key?('kube.namespace.cpu.usage')
-    end
-
-    test 'Testing kube.node.cpu.allocatable	' do
-      assert_true @@hash_map_test.key?('kube.node.cpu.allocatable')
-    end
-
-    test 'Testing kube.node.cpu.reservation	' do
-      assert_true @@hash_map_test.key?('kube.node.cpu.reservation')
-    end
-
-    test 'Testing kube.cluster.cpu.usage' do
-      assert_true @@hash_map_test.key?('kube.cluster.cpu.usage')
-    end
   end
 end


### PR DESCRIPTION
## Proposed changes

As described in https://github.com/splunk/splunk-connect-for-kubernetes/issues/204
we notice that when running Splunk in Azure Kubernetes Service some metrics stop showing up in Splunk after few hours and never show again unless pod with metric aggregator pod is restarted.

This PR tries to fix that.

We noticed that problem is in this plugin, in case of http call faliures, the timers:
https://github.com/splunk/fluent-plugin-k8s-metrics-agg/blob/cea5b8dc343b7a213ccb70de0bd26cb6cbc95c7e/lib/fluent/plugin/in_kubernetes_metrics_aggregator.rb#L160-L162

are detached:
```
2019-07-12 09:45:21 +0000 [error]: #0 Unexpected error raised. Stopping the timer. title=:resource_usage_scraper error_class=RestClient::Exceptions::OpenTimeout error="Timed out connecting to server"
```
and never run again after single network or service blip.

Hence I've added timeouts to web mocks to reproduce the issue then added error handling for methods that do http calls. I have no previous knowledge of Ruby, Fluentd so test most likely can be done better.

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/fluent-plugin-k8s-metrics-agg/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/fluent-plugin-k8s-metrics-agg/blob/develop/CLA.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

