### PR TITLE
handle unresponsive node

### DIFF
--- a/lib/fluent/plugin/in_kubernetes_metrics_aggregator.rb
+++ b/lib/fluent/plugin/in_kubernetes_metrics_aggregator.rb
@@ -573,7 +573,13 @@ module Fluent
                 end
               end
 
-            node_response = JSON.parse(node_rest_client.get(@client.headers))
+            begin
+              node_response = JSON.parse(node_rest_client.get(@client.headers))
+            rescue RestClient::ServiceUnavailable
+              log.warn("Couldn't scrap metric for node '#{node_name} as it is unavailable. Ignoring it.'")
+              next
+            end
+            
             Array(node_response['pods']).each do |pod_json|
               unless pod_json['cpu'].nil? || pod_json['memory'].nil?
                 pod_cpu_usage = pod_json['cpu'].fetch('usageNanoCores', 0)/ 1_000_000


### PR DESCRIPTION
Fixing https://github.com/splunk/fluent-plugin-k8s-metrics-agg/issues/46

Fixed issue where resource_usage_metrics would stop working if any of the cluster node isn't responsive.