### PR TITLE
Enriching kube.container.*.limit/request metrics with pod-name and namespace

### DIFF
--- a/lib/fluent/plugin/in_kubernetes_metrics_aggregator.rb
+++ b/lib/fluent/plugin/in_kubernetes_metrics_aggregator.rb
@@ -428,7 +428,7 @@ module Fluent
                 end
               end
               container_usage_metrics.add_usage_metrics(cpu_limit, cpu_request, memory_limit, memory_request)
-              container_labels = { 'name' => container_json['name'], 'image' => container_json['image'], 'node' => pod_json['spec']['nodeName'] }
+              container_labels = { 'pod-name' => pod_json['metadata']['name'], 'namespace' => pod_json['metadata']['namespace'], 'name' => container_json['name'], 'image' => container_json['image'], 'node' => pod_json['spec']['nodeName'] }
               emit_limits_requests_metrics(generate_tag('container'), @scraped_at, container_labels, container_usage_metrics)
               pod_usage_metrics.add_usage_metrics(cpu_limit, cpu_request, memory_limit, memory_request)
             end
@@ -589,7 +589,7 @@ module Fluent
               log.warn("Couldn't scrap metric for node '#{node_name} as it is unavailable. Ignoring it.'")
               next
             end
-            
+
             Array(node_response['pods']).each do |pod_json|
               unless pod_json['cpu'].nil? || pod_json['memory'].nil?
                 pod_cpu_usage = pod_json['cpu'].fetch('usageNanoCores', 0)/ 1_000_000


### PR DESCRIPTION
## Proposed changes

The following metrics are lacking pod name and namespace dimension:

-`kube.container.cpu.limit`
-`kube.container.cpu.request`
-`kube.container.memory.limit`
-`kube.container.memory.request`

In certain situations container name only is not enough, especially if it is named the same over all the pods. Add pod name and namespace helps a lot to make a clear distinction.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/fluent-plugin-k8s-metrics-agg/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/fluent-plugin-k8s-metrics-agg/blob/develop/CLA.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

