### PR TITLE
Add support for refreshing bearer token

### DIFF
--- a/docker/Gemfile
+++ b/docker/Gemfile
@@ -6,7 +6,6 @@ source 'https://rubygems.org'
 gem "fluentd", ">=1.14.2" 
 gem "fluent-plugin-prometheus", ">=2.0"
 gem "fluent-plugin-record-modifier", "=2.1.0"
-gem "fluent-plugin-kubernetes_metadata_filter", ">=2.9.2"
 gem "kubeclient", "=4.9.3"
 gem "oj", "=3.10.2"
 gem 'multi_json', '=1.14.1'

--- a/docker/Gemfile.lock
+++ b/docker/Gemfile.lock
@@ -32,10 +32,6 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
-    fluent-plugin-kubernetes_metadata_filter (2.9.5)
-      fluentd (>= 0.14.0, < 1.15)
-      kubeclient (>= 4.0.0, < 5.0.0)
-      lru_redux
     fluent-plugin-prometheus (2.0.2)
       fluentd (>= 1.9.1, < 2)
       prometheus-client (>= 2.1.0)
@@ -85,7 +81,6 @@ GEM
       jsonpath (~> 1.0)
       recursive-open-struct (~> 1.1, >= 1.1.1)
       rest-client (~> 2.0)
-    lru_redux (1.1.0)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     mime-types (3.4.1)
@@ -158,7 +153,6 @@ PLATFORMS
 DEPENDENCIES
   bigdecimal (= 3.0.0)
   fluent-plugin-k8s-metrics-agg!
-  fluent-plugin-kubernetes_metadata_filter (>= 2.9.2)
   fluent-plugin-prometheus (>= 2.0)
   fluent-plugin-record-modifier (= 2.1.0)
   fluent-plugin-splunk-hec (>= 1.2.7)

--- a/lib/fluent/plugin/in_kubernetes_metrics_aggregator.rb
+++ b/lib/fluent/plugin/in_kubernetes_metrics_aggregator.rb
@@ -177,6 +177,10 @@ module Fluent
 
       private
 
+      def update_kubeclient_header
+        @client.headers[:Authorization] = 'Bearer ' + File.read(@bearer_token_file) if @bearer_token_file
+      end
+
       def parse_tag
         @tag_prefix, @tag_suffix = @tag.split('*') if @tag.include?('*')
       end
@@ -371,6 +375,7 @@ module Fluent
       end
 
       def scrape_limits_requests_metrics
+        update_kubeclient_header
         response = limits_requests_api.get(@client.headers)
         handle_limits_requests_res(response)
       rescue StandardError => e
@@ -473,6 +478,7 @@ module Fluent
       end
 
       def scrape_node_metrics
+        update_kubeclient_header
         response = node_api.get(@client.headers)
         handle_node_response(response)
       rescue StandardError => e
@@ -556,6 +562,7 @@ module Fluent
       end
 
       def scrape_resource_usage_metrics
+        update_kubeclient_header
         response = resource_usage_api.get(@client.headers)
         handle_resource_usage_response(response)
       rescue StandardError => e


### PR DESCRIPTION
- Token will be refreshed before each API request
- removed fluent-plugin-kubernetes_metadata_filter dependency from docker as it is not used in the helm chart